### PR TITLE
fix: handle ligand-only systems in pli-lddt

### DIFF
--- a/src/peppr/metric.py
+++ b/src/peppr/metric.py
@@ -275,6 +275,11 @@ class LDDTPLIScore(Metric):
         def lddt_pli(reference, pose):  # type: ignore[no-untyped-def]
             ligand_mask = reference.hetero
             polymer_mask = ~ligand_mask
+
+            if not polymer_mask.any():
+                # No protein present -> metric is undefined
+                return np.nan
+
             binding_site_contacts = np.unique(
                 get_contact_residues(
                     reference[polymer_mask], reference[ligand_mask], cutoff=4.0

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -267,3 +267,26 @@ def test_ligand_rmsd_with_no_contacts():
     # Assert that LigandRMSD is NaN after translation
     lrmsd = metric.evaluate(reference, pose)
     assert np.isnan(lrmsd)
+
+
+@pytest.mark.parametrize("metric", ALL_METRICS, ids=lambda metric: metric.name)
+def test_ligand_only_system(metric):
+    """
+    Check that metrics work correctly when given only ligand atoms.
+    This tests that metrics don't make assumptions about the presence of protein chains
+    that could break when working with ligand-only systems.
+    """
+    # Choose any system that is suitable for all metrics
+    reference, poses = assemble_predictions("7znt__2__1.F_1.G__1.J")
+    pose = poses[0]
+
+    # Keep only ligand atoms
+    reference = reference[reference.chain_id == "LIG0"]
+    pose = pose[pose.chain_id == "LIG0"]
+
+    # The metric should still work without raising an exception
+    value = metric.evaluate(reference, pose)
+
+    # For most metrics, we expect a valid numeric value or NaN
+    # (NaN is acceptable for metrics that can't handle the input)
+    assert np.isnan(value) or isinstance(value, (int, float))


### PR DESCRIPTION
## Description
This PR adds support for ligand-only systems in metrics by:
1. Adding a new test case `test_ligand_only_system` that verifies metrics work correctly when given only ligand atoms
2. Fixing the `LDDTPLIScore` metric to properly handle cases where no protein is present by returning `NaN`

## Changes
- Added test case that filters for only ligand atoms (chain LIG0) and verifies metrics either return valid values or NaN
- Modified `LDDTPLIScore` to return `NaN` when no protein atoms are present, preventing potential errors
- Test ensures metrics don't make assumptions about the presence of protein chains
