### PR TITLE
Emphasize required atom matching

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,6 +17,7 @@ Metrics
 The metrics for pose evaluation.
 
 .. autosummary::
+    :template: detailed_class.rst
     :toctree: apidoc
     :caption: Metrics
 
@@ -42,6 +43,7 @@ Selectors
 Selection of the desired metric result from multiple poses.
 
 .. autosummary::
+    :template: detailed_class.rst
     :toctree: apidoc
     :caption: Selectors
 

--- a/docs/templates/detailed_class.rst
+++ b/docs/templates/detailed_class.rst
@@ -1,0 +1,6 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+    :members:

--- a/docs/tutorial/api.rst
+++ b/docs/tutorial/api.rst
@@ -85,13 +85,28 @@ and returns a scalar value.
 
     print(lddt_metric.evaluate(ref, pose))
 
+Note that :meth:`Metric.evaluate()` requires that the reference and pose have matching
+atoms, i.e. ``ref[i]`` and ``pose[i]`` should point to corresponding atoms.
+If this is not the case, you can use :func:`find_matching_atoms()` to get indices that
+brings the atoms into the correct order.
+
+.. jupyter-execute::
+
+    ref_indices, pose_indices = peppr.find_matching_atoms(ref, pose)
+    ref = ref[ref_indices]
+    pose = pose[pose_indices]
+
 Some metrics may not be defined for a given system.
-For example, if like in the current system there is no protein-protein interface,
-the *interface RMSD* (iRMSD) is undefined.
+For example, if we remove the second protein chain from the current system, the
+*interface RMSD* (iRMSD) is undefined.
 In such cases, :meth:`Metric.evaluate()` returns *NaN*.
 
 .. jupyter-execute::
 
+    # Remove one protein chain
+    mask = ref.chain_id != "1"
+    ref = ref[mask]
+    pose = pose[mask]
     irmsd_metric = peppr.InterfaceRMSD()
     print(irmsd_metric.evaluate(ref, pose))
 

--- a/docs/tutorial/api.rst
+++ b/docs/tutorial/api.rst
@@ -88,7 +88,7 @@ and returns a scalar value.
 Note that :meth:`Metric.evaluate()` requires that the reference and pose have matching
 atoms, i.e. ``ref[i]`` and ``pose[i]`` should point to corresponding atoms.
 If this is not the case, you can use :func:`find_matching_atoms()` to get indices that
-brings the atoms into the correct order.
+bring the atoms into the correct order.
 
 .. jupyter-execute::
 


### PR DESCRIPTION
Currently, the documentation barely mentions that `Metric.evaluate()` requires the reference and pose to have atoms in the same order.

This PR
- mentions the required atom matching the API tutorial
- and renders the method docstrings for each class (where `Metric.evaluate()` mentions the required atom order)