### PR TITLE
Support multiprocessing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ docs = [
   "sphinx-design >= 0.5",
   "sphinx-notfound-page >= 1.0",
   "numpydoc >= 1.8.0",
+  "mpire",
 ]
 lint = [
   "ruff == 0.11.0",


### PR DESCRIPTION
This PR enables parallelization of `Evaluator.feed()` over multiple systems.

On the API level `Evaluator.feed()` can be run in separate processes first and the the results are combined via the new `Evaluator.combine()` method. Not implementing multiprocessing directly on the API level allows users to utilize their preferred multiprocessing framework.

On the CLI level multiprocessing is now enabled by default. To disable it (or to set the desired number of processes) the `--cores` option is added,