### PR TITLE
feat: add variance selector

### DIFF
--- a/src/peppr/selector.py
+++ b/src/peppr/selector.py
@@ -5,6 +5,7 @@ __all__ = [
     "OracleSelector",
     "TopSelector",
     "RandomSelector",
+    "VarianceSelector",
 ]
 
 from abc import ABC, abstractmethod
@@ -164,3 +165,15 @@ class RandomSelector(Selector):
             return np.nanmin(top_values)
         else:
             return np.nanmax(top_values)
+
+class VarianceSelector(Selector):
+    """
+    Selector that computes the variance of the values.
+    """
+
+    @property
+    def name(self) -> str:
+        return "variance"
+
+    def select(self, values: np.ndarray, smaller_is_better: bool) -> float:
+        return np.nanvar(values)


### PR DESCRIPTION
This PR adds `VarianceSelector` class which straightforwardly returns the variance of a metric.

From the `Selector` base class, I think this is within the spirit of the class to return an aggregation of the metric but due to the name "Selector" I wonder if this goes against the spirit due to it no longer having the same units as the original metric.