### PR TITLE
Check for associated BondList

### DIFF
--- a/src/peppr/common.py
+++ b/src/peppr/common.py
@@ -31,6 +31,7 @@ def standardize(
 
     - removes hydrogen atoms
     - removes solvent atoms and monoatomic ions
+    - checks if an associated :class:`biotite.structure.BondList` is present
 
     Parameters
     ----------
@@ -42,6 +43,8 @@ def standardize(
     struc.AtomArray or struc.AtomArrayStack
         The standardize system.
     """
+    if system.bonds is None:
+        raise ValueError("The system must have an associated BondList")
     mask = (
         (system.element != "H")
         & ~struc.filter_solvent(system)

--- a/src/peppr/evaluator.py
+++ b/src/peppr/evaluator.py
@@ -199,15 +199,21 @@ class Evaluator(Mapping):
         The optimal atom matching is handled automatically based on the
         :class:`MatchMethod`.
         """
-        reference = standardize(reference)
-        if isinstance(poses, struc.AtomArray):
-            poses = [standardize(poses)]
-        elif isinstance(poses, struc.AtomArrayStack):
-            poses = list(standardize(poses))
-        else:
-            poses = [standardize(pose) for pose in poses]
-        if len(poses) == 0:
-            raise ValueError("No poses provided")
+        try:
+            reference = standardize(reference)
+            if isinstance(poses, struc.AtomArray):
+                poses = [standardize(poses)]
+            elif isinstance(poses, struc.AtomArrayStack):
+                poses = list(standardize(poses))
+            else:
+                poses = [standardize(pose) for pose in poses]
+            if len(poses) == 0:
+                raise ValueError("No poses provided")
+        except Exception as e:
+            self._raise_or_warn(
+                e,
+                UserWarning(f"Failed to standardize system '{system_id}': {e}"),
+            )
 
         if self._match_method in (
             Evaluator.MatchMethod.HEURISTIC,


### PR DESCRIPTION
This PR ensures that a more meaningful exception is raised if a system given to `Evaluator.feed()` has no associated `BondList`