### PR TITLE
Clarify contradiction in docstring

### DIFF
--- a/src/peppr/metric.py
+++ b/src/peppr/metric.py
@@ -19,6 +19,7 @@ __all__ = [
 ]
 
 import itertools
+import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from typing import Any, Callable, Dict, Tuple
@@ -726,11 +727,16 @@ class BondLengthViolations(Metric):
             atom2_type = pose.element[j]
 
             if (atom1_type, atom2_type) in self._reference_bonds:
-                total_checked += 1
                 bond_length = struc.distance(pose[i], pose[j])
-                ideal_lengths = self._reference_bonds[(atom1_type, atom2_type)]
+                ideal_lengths = self._reference_bonds.get((atom1_type, atom2_type))
+                if ideal_lengths is None:
+                    warnings.warn(
+                        f"No reference bond length for {atom1_type}-{atom2_type} found. Ignoring {atom1_type}-{atom2_type} bond."
+                    )
+                    continue
                 if np.any(np.abs(bond_length - ideal_lengths) <= self._tolerance):
                     valid_bonds += 1
+                total_checked += 1
 
         if total_checked == 0:
             return np.nan

--- a/src/peppr/metric.py
+++ b/src/peppr/metric.py
@@ -641,8 +641,9 @@ class BiSyRMSD(Metric):
 
 class BondLengthViolations(Metric):
     """
-    Check for unusual bond lengths in the structure by comparing against reference values.
-    Returns the percentage of bonds that are within acceptable ranges.
+    Check for unusual bond lengths in the structure by comparing against reference
+    values.
+    Returns the percentage of bonds that are outside acceptable ranges.
 
     Parameters
     ----------
@@ -744,7 +745,7 @@ class BondAngleViolations(Metric):
     """
     Check for unusual bond angles in the structure by comparing against
     idealized bond geometry.
-    Returns the percentage of bonds that are within acceptable ranges.
+    Returns the percentage of bonds that are outside acceptable ranges.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR fixes contradicting statements in `BondLengthViolations` and `BondAngleViolations`. Furthermore, it fixes the case where ideal bond lengths are not available for a combination of bonded atoms, giving a warning instead of an exception.