### PR TITLE
feat: add option to use custom names for `Metric`

### DIFF
--- a/docs/tutorial/custom.rst
+++ b/docs/tutorial/custom.rst
@@ -32,7 +32,7 @@ For the scope of this tutorial we will create an all-atom RMSD as metric.
 
         # This is mandatory
         @property
-        def name(self):
+        def _default_name(self):
             return "My awesome RMSD"
 
         # This optionally enables binning for `Evaluator.summarize_metrics()`

--- a/src/peppr/evaluator.py
+++ b/src/peppr/evaluator.py
@@ -105,6 +105,7 @@ class Evaluator(Mapping):
         min_sequence_identity: float = 0.95,
     ):
         self._metrics = tuple(metrics)
+        self._check_unique_metric_names()
         self._match_method = match_method
         self._max_matches = max_matches
         self._results: list[list[np.ndarray]] = [[] for _ in range(len(metrics))]
@@ -120,6 +121,11 @@ class Evaluator(Mapping):
     @property
     def system_ids(self) -> tuple[str, ...]:
         return tuple(self._ids)
+
+    def _check_unique_metric_names(self) -> None:
+        metric_names = [m.name for m in self._metrics]
+        if len(metric_names) != len(set(metric_names)):
+            raise ValueError(f"Metrics must have unique names, got {metric_names}")
 
     @staticmethod
     def combine(evaluators: Iterable["Evaluator"]) -> "Evaluator":

--- a/src/peppr/metric.py
+++ b/src/peppr/metric.py
@@ -51,8 +51,7 @@ class Metric(ABC):
     Parameters
     ----------
     custom_name : str, optional
-        A custom name for the metric. If not provided, each metric class will use
-        its _default_name.
+        A custom name for the metric. If not provided, the default name will be used.
 
     Attributes
     ----------
@@ -81,7 +80,15 @@ class Metric(ABC):
 
     @property
     def name(self) -> str:
-        """Return the custom name if provided, otherwise return the default name."""
+        """
+        The name of the metric.
+
+        Returns
+        -------
+        str
+            Returns the custom name if provided during instantiation, and the
+            default name otherwise.
+        """
         return (
             self._custom_name if self._custom_name is not None else self._default_name
         )
@@ -148,6 +155,8 @@ class MonomerRMSD(Metric):
     ca_only : bool, optional
         If ``True``, only consider :math:`C_{\alpha}` atoms.
         Otherwise, consider all heavy atoms.
+    custom_name : str, optional
+        A custom name for the metric. If not provided, the default name will be used.
     """
 
     def __init__(
@@ -366,6 +375,8 @@ class GlobalLDDTScore(Metric):
         If ``True``, only consider :math:`C_{\alpha}` from peptides and :math:`C_3^'`
         from nucleic acids.
         Otherwise, consider all heavy atoms.
+    custom_name : str, optional
+        A custom name for the metric. If not provided, the default name will be used.
 
     References
     ----------
@@ -406,6 +417,8 @@ class DockQScore(Metric):
     ----------
     include_pli : bool, optional
         If set to ``False``, small molecules are excluded from the calculation.
+    custom_name : str, optional
+        A custom name for the metric. If not provided, the default name will be used.
 
     References
     ----------
@@ -618,6 +631,8 @@ class BiSyRMSD(Metric):
         The minimum number of anchors to use for the superimposition.
         If less than this number of anchors are present, the superimposition is
         performed on all interface backbone atoms.
+    custom_name : str, optional
+        A custom name for the metric. If not provided, the default name will be used.
 
     References
     ----------
@@ -678,6 +693,8 @@ class BondLengthViolations(Metric):
     reference_bonds : dict, optional
         Dictionary mapping atom type pairs to ideal bond lengths.
         If not provided, uses a default set of common bond lengths.
+    custom_name : str, optional
+        A custom name for the metric. If not provided, the default name will be used.
     """
 
     # Default reference bond lengths in Angstroms
@@ -782,6 +799,8 @@ class BondAngleViolations(Metric):
     ----------
     tolerance : float, optional
         The tolerance in radians for acceptable deviation from ideal bond angles.
+    custom_name : str, optional
+        A custom name for the metric. If not provided, the default name will be used.
     """
 
     def __init__(

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -90,7 +90,7 @@ def test_tabulate_metrics_with_unsuitable_metric(selectors, match_method):
         """
 
         @property
-        def name(self):
+        def _default_name(self):
             return "Unsuitable"
 
         def evaluate(self, reference, poses):
@@ -180,7 +180,7 @@ def test_summarize_metrics_with_nan(match_method):
             super().__init__()
 
         @property
-        def name(self):
+        def _default_name(self):
             return "Metric"
 
         @property
@@ -230,7 +230,7 @@ def test_tolerate_exceptions(match_method, tolerate_exceptions):
         """
 
         @property
-        def name(self):
+        def _default_name(self):
             return "Broken"
 
         def evaluate(self, reference, poses):

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -325,3 +325,22 @@ def test_individual_match_method(model_num, optimal_bisy_rmsd):
     assert exhaustive_bisy_rmsd > optimal_bisy_rmsd + TOLERANCE
     # The individual method should be able to find the optimal value
     assert individual_bisy_rmsd <= optimal_bisy_rmsd + TOLERANCE
+
+
+def test_unique_metric_names_in_evaluator():
+    """
+    Check that the Evaluator raises a ValueError when initialized with metrics
+    that have duplicate names.
+    """
+    # Create two metrics with the same name
+    metric1 = peppr.MonomerRMSD(5.0, custom_name="Same name")
+    metric2 = peppr.MonomerLDDTScore(custom_name="Same name")
+
+    # Test that initializing with duplicate names raises ValueError
+    with pytest.raises(ValueError, match="Metrics must have unique names"):
+        peppr.Evaluator([metric1, metric2])
+
+    # Test that initializing with unique names works
+    metric2 = peppr.MonomerLDDTScore(custom_name="Different name")
+    evaluator = peppr.Evaluator([metric1, metric2])
+    assert len(evaluator.metrics) == 2, "Evaluator should contain two metrics"

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -106,9 +106,11 @@ def test_unsuitable_system(metric):
 
 def test_unique_names():
     """
-    Check if the names of the implemented metrics are unique.
+    Check if the default names of the implemented metrics are unique. Note that users can still
+    provide non-unique names via custom_name, so the Evaluator will check this separately in its
+    __init__ method.
     """
-    names = set(metric.name for metric in ALL_METRICS)
+    names = set(metric._default_name for metric in ALL_METRICS)
     assert len(names) == len(ALL_METRICS)
 
 

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -1,8 +1,8 @@
+import inspect
 import itertools
 import biotite.structure as struc
 import numpy as np
 import pytest
-import inspect
 import peppr
 from tests.common import (
     assemble_predictions,

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -123,35 +123,24 @@ def test_custom_name(metric):
     Test that metrics can be instantiated with custom names and that the name property
     returns the custom name when provided and the default name otherwise.
     """
-    # Get the default name
     default_name = metric.name
 
-    # Create a new instance with a custom name
-    custom_name = f"Custom {default_name}"
-
-    # Get the class and its parameters
+    # Create a new instance with a custom name, and using the same parameters otherwise
     metric_class = metric.__class__
-
-    # Get the original arguments used to create the metric
     init_signature = inspect.signature(metric_class.__init__)
     bound_args = init_signature.bind_partial()
     bound_args.apply_defaults()
-
-    # Remove 'self' from arguments
     args = bound_args.arguments
-    args.pop("self", None)
-
-    # Add custom name
+    custom_name = f"Custom {default_name}"
     args["custom_name"] = custom_name
 
-    # Handle positional arguments
+    # Handle metrics that require positional arguments
     if isinstance(metric, METRICS_WITH_THRESHOLDS):
         new_metric = metric_class(metric._threshold, **args)
     else:
-        # Create new instance with same parameters plus custom name
         new_metric = metric_class(**args)
 
-    # Test that the custom name is used
+    # Test that the custom name is being used
     assert new_metric.name == custom_name, (
         f"{metric_class}.name did not return custom name"
     )


### PR DESCRIPTION
## Description

This PR adds the option to pass a `custom_name` parameter to any `Metric`. This is useful to e.g. evaluate a pose with the same `Metric` instantiated using different parameters. 

## Key changes made

### changed

- `Metric` accepts a `custom_name` kwarg which gets stored in `self._custom_name`
- the `default_name` property of `Metric` takes the place of the `name` property (i.e., hardcoded name per metric) 
- the `name` property of `Metric` now returns either `self._custom_name` (if it exists) or `self._default_name`. If no `custom_name` is provided, previous functionality remains unchanged. 
**Note on backwards incompatibility**: If users have implemented their own `Metric` implementation, they would have to rename the `name` property to `_default_name` to avoid `TypeError: Can't instantiate abstract class <USER_CLASS_NAME> with abstract method _default_name`
- added a check in the `Evalutor`'s `__init__` method to ensure we have unique metric names

## Test changes

### added

- `test_custom_name` to check that passing `custom_name="custom_name"` does indeed change what `metric.name` returns
- `test_unique_metric_names_in_evaluator` to check that we raise an error if we try to instantiate an `Evaluator` with `Metric`'s that have duplicate names


## Checklist

- [x] Tests added/updated
- [x] Documentation updated
