### PR TITLE
Ensure public API is documented

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -36,6 +36,7 @@ The metrics for pose evaluation.
     PocketAlignedLigandRMSD
     BiSyRMSD
     BondLengthViolations
+    BondAngleViolations
     ClashCount
 
 Selectors

--- a/src/peppr/__init__.py
+++ b/src/peppr/__init__.py
@@ -3,8 +3,6 @@ from .clashes import *
 from .common import *
 from .dockq import *
 from .evaluator import *
-from .graph import *
-from .idealize import *
 from .match import *
 from .metric import *
 from .sanitize import *

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,22 @@
+import types
+from pathlib import Path
+import peppr
+
+DOCS_DIR = Path(__file__).parents[1] / "docs"
+
+
+def test_public_api_reference():
+    """
+    Check if every function/class that is part of the public API is documented
+    in the API reference, i.e. in the ``api.rst`` file.
+    """
+    with open(DOCS_DIR / "api.rst") as api_reference_file:
+        api_reference = api_reference_file.read()
+
+    for attr_name in dir(peppr):
+        if attr_name.startswith("_"):
+            continue
+        attribute = getattr(peppr, attr_name)
+        # Check classes and functions
+        if isinstance(attribute, (type, types.FunctionType)):
+            assert attr_name in api_reference, f"Missing entry for '{attr_name}'"


### PR DESCRIPTION
When adding a new class or function to the public API, it also must be manually added to `api.rst` to appear in the API reference. However, currently no test actually ensures that this is done. This PR adds a test for this and fixes a case where a class was not added to `api.rst`.