### PR TITLE
Allow a molecule in kekulized form to be matched to an aromatic molecule

### DIFF
--- a/src/peppr/match.py
+++ b/src/peppr/match.py
@@ -1005,8 +1005,11 @@ def _to_mol(molecule: struc.AtomArray) -> Mol:
     mol = rdkit_interface.to_mol(molecule)
     # Make RDKit distinguish stereoisomers when matching atoms
     AssignStereochemistryFrom3D(mol)
-    # Make conjugated terminal groups symmetric (e.g. carboxyl oxygen atoms)
-    SanitizeMol(mol, SanitizeFlags.SANITIZE_SETCONJUGATION)
+    SanitizeMol(
+        mol,
+        SanitizeFlags.SANITIZE_SETCONJUGATION | SanitizeFlags.SANITIZE_SETAROMATICITY,
+    )
+    # Make conjugated terminal groups truly symmetric (e.g. carboxyl oxygen atoms)
     for bond in mol.GetBonds():
         if bond.GetIsConjugated() and bond.GetBondType() in [
             BondType.SINGLE,


### PR DESCRIPTION
Currently `peppr` sees a molecule with aromatic bonds and a molecule with kekulized bonds as two different things during atom matching, hence you would not get a proper matching along with a `GraphMatchWarning` in such cases. This PR sets the aromaticity during sanitation to make such molecules matchable to each other.