### PR TITLE
Fix sanitation of multiple`AtomValenceException`

### DIFF
--- a/src/peppr/sanitize.py
+++ b/src/peppr/sanitize.py
@@ -110,8 +110,13 @@ def _is_same_problem(problem1: Exception, problem2: Exception) -> bool:
     same : bool
         True if the two problems are the same.
     """
-    if problem1.GetType() != problem2.GetType():
+    problem_type = problem1.GetType()
+    if problem_type != problem2.GetType():
         return False
-    if problem1.GetAtomIndices() != problem2.GetAtomIndices():
-        return False
+    elif problem_type == "AtomValenceException":
+        if problem1.GetAtomIdx() != problem2.GetAtomIdx():
+            return False
+    elif problem_type == "KekulizeException":
+        if problem1.GetAtomIndices() != problem2.GetAtomIndices():
+            return False
     return True

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -3,6 +3,7 @@ from rdkit import Chem
 from peppr.sanitize import sanitize
 
 
+@pytest.mark.parametrize("multiple_problems", [False, True])
 @pytest.mark.parametrize(
     "smiles",
     [
@@ -12,7 +13,16 @@ from peppr.sanitize import sanitize
         "C1CCCC=O1",
     ],
 )
-def test_soft_rdkit_sanitize_mol(smiles):
+def test_sanitize(smiles, multiple_problems):
+    """
+    Check if :func:`sanitize()` is able to fix the chemistry problems in the
+    given molecules.
+
+    Also check if molecules with the same problem appearing multiple times can
+    be solved, by creating a :class:`Mol` containing two copies of the molecule.
+    """
+    if multiple_problems:
+        smiles = smiles + "." + smiles
     mol = Chem.MolFromSmiles(smiles, sanitize=False)
     assert len(Chem.DetectChemistryProblems(mol)) > 0
     sanitize(mol)


### PR DESCRIPTION
Fixes the following non-descriptive exception in `sanitize()`, if the molecule has an `AtomValenceException`:
```
AttributeError: '_cppAtomValenceException' object has no attribute 'GetAtomIndices'
```