### PR TITLE
Require NumPy 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 
 dependencies = [
   "biotite >= 1.2",
-  "numpy >= 1.25",
+  "numpy >= 2.0",
   "pandas >= 2.0.0",
   "rdkit >= 2024.09.1",
   "click >= 8.0.0",


### PR DESCRIPTION
NumPy 2.0 added some breaking API changes, including that some functions now return NumPy scalars instead of Python's built-in types (e.g. `np.float64` instead of `float`). This can lead to some errors: https://github.com/aivant/peppr/pull/39#discussion_r2183499745

As NumPy 2.0 is now more than a year old, I think it is reasonable to pin `numpy>=2.0`