### PR TITLE
Fix unbound local variable exception

### DIFF
--- a/src/peppr/evaluator.py
+++ b/src/peppr/evaluator.py
@@ -413,6 +413,7 @@ class Evaluator(Mapping):
                     f"Failed to match reference and pose in system '{system_id}': {e}"
                 ),
             )
+            return results
 
         for i, metric in enumerate(self._metrics):
             try:


### PR DESCRIPTION
Removes the spurois `EvaluationWarning` raised, when pose and reference cannot be matched to each other, i.e.

```
cannot access local variable 'matched_reference'
```

so that only the `MatchWarning` remains.