### PR TITLE
Add score bins for TM-score

### DIFF
--- a/src/peppr/metric.py
+++ b/src/peppr/metric.py
@@ -209,6 +209,17 @@ class MonomerTMScore(Metric):
     def name(self) -> str:
         return "TM-score"
 
+    @property
+    def thresholds(self) -> OrderedDict[str, float]:
+        # Bins are adopted from https://doi.org/10.1093/nar/gki524
+        return OrderedDict(
+            [
+                ("random", 0.00),
+                ("ambiguous", 0.17),
+                ("similar", 0.50),
+            ]
+        )
+
     def evaluate(self, reference: struc.AtomArray, pose: struc.AtomArray) -> float:
         def superimpose_and_tm_score(reference, pose):  # type: ignore[no-untyped-def]
             # Use 'superimpose_structural_homologs()' instead of 'superimpose()',

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -139,6 +139,9 @@ def test_summarize_metrics(
         "intra protein lDDT median",
         "TM-score mean",
         "TM-score median",
+        "TM-score random",
+        "TM-score ambiguous",
+        "TM-score similar",
     ]
     SELECTOR_NAMES = ["mean", "Oracle"]
 


### PR DESCRIPTION
Based on the findings from https://doi.org/10.1093/nar/gki524, this PR adds more granular score bins to `MonomerTMScore`.