### PR TITLE
Fix `LDDTPLIScore` for multiple ligand where some have no contact

### DIFF
--- a/src/peppr/metric.py
+++ b/src/peppr/metric.py
@@ -1721,7 +1721,7 @@ def _average_over_ligands(
         # No ligands in the structure
         return np.nan
     else:
-        return np.mean(values).item()
+        return np.nanmean(values).item()
 
 
 def _run_for_each_ligand(


### PR DESCRIPTION
The LDDT-PLI is reasonably defined as *NaN* if the reference small molecule has no contact to its receptor. However, currently it is enough if only one of multiple small molecules has no contact to render the entire metric NaN. This PR fixes this.