### PR TITLE
Emphasize the input structure requirements in the docs

### DIFF
--- a/docs/tutorial/api.rst
+++ b/docs/tutorial/api.rst
@@ -180,6 +180,12 @@ classes such as :class:`DockQScore`.
     for bin, lower_threshold in peppr.DockQScore().thresholds.items():
         print(f"{bin}: {lower_threshold:.2f}")
 
+.. note::
+
+    The input ``AtomArray`` objects need to fulfill some requirements to ensure that
+    the reference and pose can be correctly matched.
+    See the ``Notes`` section in :meth:`Evaluator.feed()` for more details.
+
 Selecting the right pose
 ------------------------
 Until now we fed only a single pose per system to the :class:`Evaluator`.

--- a/src/peppr/evaluator.py
+++ b/src/peppr/evaluator.py
@@ -206,6 +206,8 @@ class Evaluator(Mapping):
           small molecule.
           Conversely, chains where the ``hetero`` annotation is ``False`` is always
           interpreted as protein or nucleic acid chain.
+        - Two small molecules can only be matched to each other if they have the same
+          ``res_name``.
 
         The optimal atom matching is handled automatically based on the
         :class:`MatchMethod`.

--- a/src/peppr/match.py
+++ b/src/peppr/match.py
@@ -140,6 +140,7 @@ def find_optimal_match(
     them is minimized.
 
     'Matching' has two effects here:
+
     - Chains and atoms within each residue *that have a counterpart* in the respective
       other structure, are reordered if necessary so that they are in the same order.
     - A ``matched`` annotation is added, which is ``False`` for all atoms, that
@@ -183,6 +184,7 @@ def find_optimal_match(
     -----
     Atoms that are not matched (``matched=False``), are positioned in the reordered
     return value as follows:
+
     - Unmatched chains are appended to the end.
     - Unmatched residues within a matched chain are kept at their original sequence
       position.


### PR DESCRIPTION
Currently some expectations of `Evaluator.feed()` one the input `reference` and `poses` are quite hidden. This PR mentions them more prominently in the API tutorial.